### PR TITLE
MaybeValue<TValue> everywhere

### DIFF
--- a/src/ZiggyCreatures.FusionCache/FusionCache.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCache.cs
@@ -272,8 +272,15 @@ namespace ZiggyCreatures.Caching.Fusion
 			{
 				if (options.IsFailSafeEnabled && _memoryEntry is object)
 				{
+					// CREATE A NEW (THROTTLED) ENTRY
+					_memoryEntry = FusionCacheMemoryEntry.CreateFromOptions(_memoryEntry.Value, options, true);
+
+					// SAVING THE DATA IN THE MEMORY CACHE (EVEN IF IT IS FROM FAIL-SAFE)
+					_mca.SetEntry<TValue>(operationId, key, _memoryEntry, options);
+
 					if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
 						_logger.LogTrace("FUSION (K={CacheKey} OP={CacheOperationId}): using memory entry (expired)", key, operationId);
+
 					return _memoryEntry;
 				}
 
@@ -427,8 +434,15 @@ namespace ZiggyCreatures.Caching.Fusion
 			{
 				if (options.IsFailSafeEnabled && _memoryEntry is object)
 				{
+					// CREATE A NEW (THROTTLED) ENTRY
+					_memoryEntry = FusionCacheMemoryEntry.CreateFromOptions(_memoryEntry.Value, options, true);
+
+					// SAVING THE DATA IN THE MEMORY CACHE (EVEN IF IT IS FROM FAIL-SAFE)
+					_mca.SetEntry<TValue>(operationId, key, _memoryEntry, options);
+
 					if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
 						_logger.LogTrace("FUSION (K={CacheKey} OP={CacheOperationId}): using memory entry (expired)", key, operationId);
+
 					return _memoryEntry;
 				}
 

--- a/src/ZiggyCreatures.FusionCache/FusionCache.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCache.cs
@@ -677,7 +677,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		}
 
 		/// <inheritdoc/>
-		public async Task<TryGetResult<TValue>> TryGetAsync<TValue>(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default)
+		public async Task<MaybeValue<TValue>> TryGetAsync<TValue>(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default)
 		{
 			ValidateCacheKey(key);
 
@@ -697,17 +697,17 @@ namespace ZiggyCreatures.Caching.Fusion
 				if (_logger?.IsEnabled(LogLevel.Debug) ?? false)
 					_logger.LogDebug("FUSION (K={CacheKey} OP={CacheOperationId}): return NO SUCCESS", key, operationId);
 
-				return TryGetResult<TValue>.NoSuccess;
+				return default;
 			}
 
 			if (_logger?.IsEnabled(LogLevel.Debug) ?? false)
 				_logger.LogDebug("FUSION (K={CacheKey} OP={CacheOperationId}): return SUCCESS", key, operationId);
 
-			return TryGetResult<TValue>.CreateSuccess(entry.GetValue<TValue>());
+			return entry.GetValue<TValue>();
 		}
 
 		/// <inheritdoc/>
-		public TryGetResult<TValue> TryGet<TValue>(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default)
+		public MaybeValue<TValue> TryGet<TValue>(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default)
 		{
 			ValidateCacheKey(key);
 
@@ -727,13 +727,13 @@ namespace ZiggyCreatures.Caching.Fusion
 				if (_logger?.IsEnabled(LogLevel.Debug) ?? false)
 					_logger.LogDebug("FUSION (K={CacheKey} OP={CacheOperationId}): return NO SUCCESS", key, operationId);
 
-				return TryGetResult<TValue>.NoSuccess;
+				return default;
 			}
 
 			if (_logger?.IsEnabled(LogLevel.Debug) ?? false)
 				_logger.LogDebug("FUSION (K={CacheKey} OP={CacheOperationId}): return SUCCESS", key, operationId);
 
-			return TryGetResult<TValue>.CreateSuccess(entry.GetValue<TValue>());
+			return entry.GetValue<TValue>();
 		}
 
 		/// <inheritdoc/>

--- a/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods.cs
@@ -308,29 +308,27 @@ namespace ZiggyCreatures.Caching.Fusion
 		#region TryGet overloads
 
 		/// <summary>
-		/// Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="TryGetResult{TValue}"/> instance.
+		/// Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="MaybeValue{TValue}"/> instance.
 		/// </summary>
 		/// <typeparam name="TValue">The type of the value in the cache.</typeparam>
 		/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 		/// <param name="key">The cache key which identifies the entry in the cache.</param>
 		/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.DefaultEntryOptions"/>.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
-		/// <returns>A <see cref="TryGetResult{TValue}"/> instance containing a <see cref="bool"/> indicating if the value was there or not and either the value or a default one.</returns>
-		public static Task<TryGetResult<TValue>> TryGetAsync<TValue>(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
+		public static Task<MaybeValue<TValue>> TryGetAsync<TValue>(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 		{
 			return cache.TryGetAsync<TValue>(key, cache.CreateEntryOptions(setupAction), token);
 		}
 
 		/// <summary>
-		/// Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="TryGetResult{TValue}"/> instance.
+		/// Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="MaybeValue{TValue}"/> instance.
 		/// </summary>
 		/// <typeparam name="TValue">The type of the value in the cache.</typeparam>
 		/// <param name="cache">The <see cref="IFusionCache"/> instance.</param>
 		/// <param name="key">The cache key which identifies the entry in the cache.</param>
 		/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.DefaultEntryOptions"/>.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
-		/// <returns>A <see cref="TryGetResult{TValue}"/> instance containing a <see cref="bool"/> indicating if the value was there or not and either the value or a default one.</returns>
-		public static TryGetResult<TValue> TryGet<TValue>(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
+		public static MaybeValue<TValue> TryGet<TValue>(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 		{
 			return cache.TryGet<TValue>(key, cache.CreateEntryOptions(setupAction), token);
 		}

--- a/src/ZiggyCreatures.FusionCache/IFusionCache.cs
+++ b/src/ZiggyCreatures.FusionCache/IFusionCache.cs
@@ -107,24 +107,22 @@ namespace ZiggyCreatures.Caching.Fusion
 		TValue GetOrDefault<TValue>(string key, TValue defaultValue = default, FusionCacheEntryOptions? options = null, CancellationToken token = default);
 
 		/// <summary>
-		/// Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="TryGetResult{TValue}"/> instance.
+		/// Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="MaybeValue{TValue}"/> instance.
 		/// </summary>
 		/// <typeparam name="TValue">The type of the value in the cache.</typeparam>
 		/// <param name="key">The cache key which identifies the entry in the cache.</param>
 		/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
-		/// <returns>A <see cref="TryGetResult{TValue}"/> instance containing a <see cref="bool"/> indicating if the value was there or not and either the value or a default one.</returns>
-		Task<TryGetResult<TValue>> TryGetAsync<TValue>(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default);
+		Task<MaybeValue<TValue>> TryGetAsync<TValue>(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default);
 
 		/// <summary>
-		/// Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="TryGetResult{TValue}"/> instance.
+		/// Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="MaybeValue{TValue}"/> instance.
 		/// </summary>
 		/// <typeparam name="TValue">The type of the value in the cache.</typeparam>
 		/// <param name="key">The cache key which identifies the entry in the cache.</param>
 		/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
-		/// <returns>A <see cref="TryGetResult{TValue}"/> instance containing a <see cref="bool"/> indicating if the value was there or not and either the value or a default one.</returns>
-		TryGetResult<TValue> TryGet<TValue>(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default);
+		MaybeValue<TValue> TryGet<TValue>(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default);
 
 		/// <summary>
 		/// Put the <paramref name="value"/> in the cache for the specified <paramref name="key"/> with the provided <paramref name="options"/>. If a value is already there it will be overwritten.

--- a/src/ZiggyCreatures.FusionCache/MaybeValue.cs
+++ b/src/ZiggyCreatures.FusionCache/MaybeValue.cs
@@ -29,6 +29,15 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <summary>
 		/// Indicates if the value is there.
 		/// </summary>
+		[Obsolete("Please use HasValue instead")]
+		public bool Success
+		{
+			get { return HasValue; }
+		}
+
+		/// <summary>
+		/// Indicates if the value is there.
+		/// </summary>
 		public bool HasValue { get; private set; }
 
 		/// <summary>

--- a/src/ZiggyCreatures.FusionCache/TryGetResult.cs
+++ b/src/ZiggyCreatures.FusionCache/TryGetResult.cs
@@ -7,6 +7,7 @@ namespace ZiggyCreatures.Caching.Fusion
 	/// Represents the result of a TryGet[Async] operation: it contains a <see cref="bool"/> indicating if the value has been found, and either the found value or a default value instead.
 	/// </summary>
 	/// <typeparam name="TValue">The type of the value in the cache.</typeparam>
+	[Obsolete("Please use MaybeValue<T> instead")]
 	public struct TryGetResult<TValue>
 	{
 

--- a/src/ZiggyCreatures.FusionCache/ZiggyCreatures.FusionCache.xml
+++ b/src/ZiggyCreatures.FusionCache/ZiggyCreatures.FusionCache.xml
@@ -664,25 +664,23 @@
         </member>
         <member name="M:ZiggyCreatures.Caching.Fusion.FusionCacheExtMethods.TryGetAsync``1(ZiggyCreatures.Caching.Fusion.IFusionCache,System.String,System.Action{ZiggyCreatures.Caching.Fusion.FusionCacheEntryOptions},System.Threading.CancellationToken)">
             <summary>
-            Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="T:ZiggyCreatures.Caching.Fusion.TryGetResult`1"/> instance.
+            Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="T:ZiggyCreatures.Caching.Fusion.MaybeValue`1"/> instance.
             </summary>
             <typeparam name="TValue">The type of the value in the cache.</typeparam>
             <param name="cache">The <see cref="T:ZiggyCreatures.Caching.Fusion.IFusionCache"/> instance.</param>
             <param name="key">The cache key which identifies the entry in the cache.</param>
             <param name="setupAction">The setup action used to further configure the newly created <see cref="T:ZiggyCreatures.Caching.Fusion.FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="P:ZiggyCreatures.Caching.Fusion.FusionCacheOptions.DefaultEntryOptions"/>.</param>
             <param name="token">An optional <see cref="T:System.Threading.CancellationToken"/> to cancel the operation.</param>
-            <returns>A <see cref="T:ZiggyCreatures.Caching.Fusion.TryGetResult`1"/> instance containing a <see cref="T:System.Boolean"/> indicating if the value was there or not and either the value or a default one.</returns>
         </member>
         <member name="M:ZiggyCreatures.Caching.Fusion.FusionCacheExtMethods.TryGet``1(ZiggyCreatures.Caching.Fusion.IFusionCache,System.String,System.Action{ZiggyCreatures.Caching.Fusion.FusionCacheEntryOptions},System.Threading.CancellationToken)">
             <summary>
-            Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="T:ZiggyCreatures.Caching.Fusion.TryGetResult`1"/> instance.
+            Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="T:ZiggyCreatures.Caching.Fusion.MaybeValue`1"/> instance.
             </summary>
             <typeparam name="TValue">The type of the value in the cache.</typeparam>
             <param name="cache">The <see cref="T:ZiggyCreatures.Caching.Fusion.IFusionCache"/> instance.</param>
             <param name="key">The cache key which identifies the entry in the cache.</param>
             <param name="setupAction">The setup action used to further configure the newly created <see cref="T:ZiggyCreatures.Caching.Fusion.FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="P:ZiggyCreatures.Caching.Fusion.FusionCacheOptions.DefaultEntryOptions"/>.</param>
             <param name="token">An optional <see cref="T:System.Threading.CancellationToken"/> to cancel the operation.</param>
-            <returns>A <see cref="T:ZiggyCreatures.Caching.Fusion.TryGetResult`1"/> instance containing a <see cref="T:System.Boolean"/> indicating if the value was there or not and either the value or a default one.</returns>
         </member>
         <member name="M:ZiggyCreatures.Caching.Fusion.FusionCacheExtMethods.SetAsync``1(ZiggyCreatures.Caching.Fusion.IFusionCache,System.String,``0,System.TimeSpan,System.Threading.CancellationToken)">
             <summary>
@@ -980,23 +978,21 @@
         </member>
         <member name="M:ZiggyCreatures.Caching.Fusion.IFusionCache.TryGetAsync``1(System.String,ZiggyCreatures.Caching.Fusion.FusionCacheEntryOptions,System.Threading.CancellationToken)">
             <summary>
-            Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="T:ZiggyCreatures.Caching.Fusion.TryGetResult`1"/> instance.
+            Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="T:ZiggyCreatures.Caching.Fusion.MaybeValue`1"/> instance.
             </summary>
             <typeparam name="TValue">The type of the value in the cache.</typeparam>
             <param name="key">The cache key which identifies the entry in the cache.</param>
             <param name="options">The options to adhere during this operation. If null is passed, <see cref="P:ZiggyCreatures.Caching.Fusion.IFusionCache.DefaultEntryOptions"/> will be used.</param>
             <param name="token">An optional <see cref="T:System.Threading.CancellationToken"/> to cancel the operation.</param>
-            <returns>A <see cref="T:ZiggyCreatures.Caching.Fusion.TryGetResult`1"/> instance containing a <see cref="T:System.Boolean"/> indicating if the value was there or not and either the value or a default one.</returns>
         </member>
         <member name="M:ZiggyCreatures.Caching.Fusion.IFusionCache.TryGet``1(System.String,ZiggyCreatures.Caching.Fusion.FusionCacheEntryOptions,System.Threading.CancellationToken)">
             <summary>
-            Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="T:ZiggyCreatures.Caching.Fusion.TryGetResult`1"/> instance.
+            Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="T:ZiggyCreatures.Caching.Fusion.MaybeValue`1"/> instance.
             </summary>
             <typeparam name="TValue">The type of the value in the cache.</typeparam>
             <param name="key">The cache key which identifies the entry in the cache.</param>
             <param name="options">The options to adhere during this operation. If null is passed, <see cref="P:ZiggyCreatures.Caching.Fusion.IFusionCache.DefaultEntryOptions"/> will be used.</param>
             <param name="token">An optional <see cref="T:System.Threading.CancellationToken"/> to cancel the operation.</param>
-            <returns>A <see cref="T:ZiggyCreatures.Caching.Fusion.TryGetResult`1"/> instance containing a <see cref="T:System.Boolean"/> indicating if the value was there or not and either the value or a default one.</returns>
         </member>
         <member name="M:ZiggyCreatures.Caching.Fusion.IFusionCache.SetAsync``1(System.String,``0,ZiggyCreatures.Caching.Fusion.FusionCacheEntryOptions,System.Threading.CancellationToken)">
             <summary>
@@ -1329,6 +1325,11 @@
         <member name="F:ZiggyCreatures.Caching.Fusion.MaybeValue`1.None">
             <summary>
             Represents a reusable result to be used when no value is there: using this saves memory allocations.
+            </summary>
+        </member>
+        <member name="P:ZiggyCreatures.Caching.Fusion.MaybeValue`1.Success">
+            <summary>
+            Indicates if the value is there.
             </summary>
         </member>
         <member name="P:ZiggyCreatures.Caching.Fusion.MaybeValue`1.HasValue">

--- a/tests/ZiggyCreatures.FusionCache.Tests/ExecutionUtilsTests.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/ExecutionUtilsTests.cs
@@ -64,7 +64,7 @@ namespace ZiggyCreatures.Caching.Fusion.Tests
 			var factoryTerminated = false;
 			var outerCancelDelayMs = 500;
 			var innerDelayMs = 2_000;
-			await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+			await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
 			{
 				var cts = new CancellationTokenSource(outerCancelDelayMs);
 				res = await FusionCacheExecutionUtils.RunAsyncFuncWithTimeoutAsync(async ct => { await Task.Delay(innerDelayMs); ct.ThrowIfCancellationRequested(); factoryTerminated = true; return 42; }, Timeout.InfiniteTimeSpan, true, token: cts.Token);
@@ -82,7 +82,7 @@ namespace ZiggyCreatures.Caching.Fusion.Tests
 			var factoryTerminated = false;
 			var outerCancelDelayMs = 500;
 			var innerDelayMs = 2_000;
-			Assert.Throws<OperationCanceledException>(() =>
+			Assert.ThrowsAny<OperationCanceledException>(() =>
 			{
 				var cts = new CancellationTokenSource(outerCancelDelayMs);
 				res = FusionCacheExecutionUtils.RunAsyncFuncWithTimeout(async ct => { await Task.Delay(innerDelayMs); ct.ThrowIfCancellationRequested(); factoryTerminated = true; return 42; }, Timeout.InfiniteTimeSpan, true, token: cts.Token);

--- a/tests/ZiggyCreatures.FusionCache.Tests/SingleLevelTests.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/SingleLevelTests.cs
@@ -375,12 +375,12 @@ namespace ZiggyCreatures.Caching.Fusion.Tests
 				var res1 = await cache.TryGetAsync<int>("foo");
 				await cache.SetAsync<int>("foo", 42);
 				var res2 = await cache.TryGetAsync<int>("foo");
-				Assert.False(res1.Success);
+				Assert.False(res1.HasValue);
 				Assert.Throws<InvalidOperationException>(() =>
 				{
 					var foo = res1.Value;
 				});
-				Assert.True(res2.Success);
+				Assert.True(res2.HasValue);
 				Assert.Equal(42, res2.Value);
 			}
 		}
@@ -393,12 +393,12 @@ namespace ZiggyCreatures.Caching.Fusion.Tests
 				var res1 = cache.TryGet<int>("foo");
 				cache.Set<int>("foo", 42);
 				var res2 = cache.TryGet<int>("foo");
-				Assert.False(res1.Success);
+				Assert.False(res1.HasValue);
 				Assert.Throws<InvalidOperationException>(() =>
 				{
 					var foo = res1.Value;
 				});
-				Assert.True(res2.Success);
+				Assert.True(res2.HasValue);
 				Assert.Equal(42, res2.Value);
 			}
 		}
@@ -507,7 +507,7 @@ namespace ZiggyCreatures.Caching.Fusion.Tests
 				var baz = await cache.TryGetAsync<int>("foo", opt => opt.SetDuration(TimeSpan.FromHours(24)));
 				Assert.Equal(42, foo);
 				Assert.Equal(21, bar);
-				Assert.False(baz.Success);
+				Assert.False(baz.HasValue);
 			}
 		}
 
@@ -521,7 +521,7 @@ namespace ZiggyCreatures.Caching.Fusion.Tests
 				var baz = cache.TryGet<int>("foo", opt => opt.SetDuration(TimeSpan.FromHours(24)));
 				Assert.Equal(42, foo);
 				Assert.Equal(21, bar);
-				Assert.False(baz.Success);
+				Assert.False(baz.HasValue);
 			}
 		}
 


### PR DESCRIPTION
Stopped using `TryGetResult<TValue>` and started using `MaybeValue<TValue>` both as the fail-safe default value and as the return value of the `TryGet[Async]` method, to obtain more consistency in the codebase.