### PR TITLE
Switch from Task<T> to ValueTask<T>

### DIFF
--- a/benchmarks/ZiggyCreatures.FusionCache.Benchmarks/ParallelComparisonBenchmark.cs
+++ b/benchmarks/ZiggyCreatures.FusionCache.Benchmarks/ParallelComparisonBenchmark.cs
@@ -87,7 +87,7 @@ namespace ZiggyCreatures.Caching.Fusion.Benchmarks
 								  return new SamplePayload();
 							  }
 						  );
-						   tasks.Add(t);
+						   tasks.Add(t.AsTask());
 					   });
 					});
 

--- a/benchmarks/ZiggyCreatures.FusionCache.Benchmarks/Program.cs
+++ b/benchmarks/ZiggyCreatures.FusionCache.Benchmarks/Program.cs
@@ -8,7 +8,8 @@ namespace ZiggyCreatures.Caching.Fusion.Benchmarks
 
 		public static async Task Main(string[] args)
 		{
-			_ = BenchmarkRunner.Run<SequentialComparisonBenchmarkAsync>();
+			_ = BenchmarkRunner.Run<ParallelComparisonBenchmark>();
+			//_ = BenchmarkRunner.Run<SequentialComparisonBenchmarkAsync>();
 			//_ = BenchmarkRunner.Run<SequentialComparisonBenchmarkSync>();
 		}
 

--- a/benchmarks/ZiggyCreatures.FusionCache.Benchmarks/SequentialComparisonBenchmarkAsync.cs
+++ b/benchmarks/ZiggyCreatures.FusionCache.Benchmarks/SequentialComparisonBenchmarkAsync.cs
@@ -30,7 +30,7 @@ namespace ZiggyCreatures.Caching.Fusion.Benchmarks
 			}
 		}
 
-		[Params(100)]
+		[Params(200)]
 		public int KeysCount;
 
 		[Params(1, 50)]

--- a/benchmarks/ZiggyCreatures.FusionCache.Benchmarks/SequentialComparisonBenchmarkSync.cs
+++ b/benchmarks/ZiggyCreatures.FusionCache.Benchmarks/SequentialComparisonBenchmarkSync.cs
@@ -27,7 +27,7 @@ namespace ZiggyCreatures.Caching.Fusion.Benchmarks
 			}
 		}
 
-		[Params(100)]
+		[Params(200)]
 		public int KeysCount;
 
 		[Params(1, 50)]

--- a/src/ZiggyCreatures.FusionCache.Serialization.NewtonsoftJson/FusionCacheNewtonsoftJsonSerializer.cs
+++ b/src/ZiggyCreatures.FusionCache.Serialization.NewtonsoftJson/FusionCacheNewtonsoftJsonSerializer.cs
@@ -41,17 +41,17 @@ namespace ZiggyCreatures.Caching.Fusion.Serialization.NewtonsoftJson
 		}
 
 		/// <inheritdoc />
-		public Task<byte[]> SerializeAsync<T>(T obj)
+		public ValueTask<byte[]> SerializeAsync<T>(T obj)
 		{
 			// TODO: DO BETTER HERE
-			return Task.FromResult(Serialize<T>(obj));
+			return new ValueTask<byte[]>(Serialize<T>(obj));
 		}
 
 		/// <inheritdoc />
-		public Task<T> DeserializeAsync<T>(byte[] data)
+		public ValueTask<T> DeserializeAsync<T>(byte[] data)
 		{
 			// TODO: DO BETTER HERE
-			return Task.FromResult(Deserialize<T>(data));
+			return new ValueTask<T>(Deserialize<T>(data));
 		}
 	}
 

--- a/src/ZiggyCreatures.FusionCache.Serialization.SystemTextJson/FusionCacheSystemTextJsonSerializer.cs
+++ b/src/ZiggyCreatures.FusionCache.Serialization.SystemTextJson/FusionCacheSystemTextJsonSerializer.cs
@@ -35,7 +35,7 @@ namespace ZiggyCreatures.Caching.Fusion.Serialization.SystemTextJson
 		}
 
 		/// <inheritdoc />
-		public async Task<byte[]> SerializeAsync<T>(T obj)
+		public async ValueTask<byte[]> SerializeAsync<T>(T obj)
 		{
 			using (var stream = new MemoryStream())
 			{
@@ -45,7 +45,7 @@ namespace ZiggyCreatures.Caching.Fusion.Serialization.SystemTextJson
 		}
 
 		/// <inheritdoc />
-		public async Task<T> DeserializeAsync<T>(byte[] data)
+		public async ValueTask<T> DeserializeAsync<T>(byte[] data)
 		{
 			using (var stream = new MemoryStream(data))
 			{

--- a/src/ZiggyCreatures.FusionCache/FusionCache.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCache.cs
@@ -275,7 +275,7 @@ namespace ZiggyCreatures.Caching.Fusion
 			_events.OnFactoryError(operationId, key);
 		}
 
-		private async Task<IFusionCacheEntry?> GetOrSetEntryInternalAsync<TValue>(string operationId, string key, Func<CancellationToken, Task<TValue>>? factory, MaybeValue<TValue> failSafeDefaultValue, FusionCacheEntryOptions? options, CancellationToken token)
+		private async ValueTask<IFusionCacheEntry?> GetOrSetEntryInternalAsync<TValue>(string operationId, string key, Func<CancellationToken, Task<TValue>>? factory, MaybeValue<TValue> failSafeDefaultValue, FusionCacheEntryOptions? options, CancellationToken token)
 		{
 			if (options is null)
 				options = _options.DefaultEntryOptions;
@@ -672,7 +672,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		}
 
 		/// <inheritdoc/>
-		public async Task<TValue> GetOrSetAsync<TValue>(string key, Func<CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue = default, FusionCacheEntryOptions? options = null, CancellationToken token = default)
+		public async ValueTask<TValue> GetOrSetAsync<TValue>(string key, Func<CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue = default, FusionCacheEntryOptions? options = null, CancellationToken token = default)
 		{
 			ValidateCacheKey(key);
 
@@ -734,7 +734,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		}
 
 		/// <inheritdoc/>
-		public async Task<TValue> GetOrSetAsync<TValue>(string key, TValue defaultValue, FusionCacheEntryOptions? options = null, CancellationToken token = default)
+		public async ValueTask<TValue> GetOrSetAsync<TValue>(string key, TValue defaultValue, FusionCacheEntryOptions? options = null, CancellationToken token = default)
 		{
 			ValidateCacheKey(key);
 
@@ -792,7 +792,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		}
 
 		/// <inheritdoc/>
-		public async Task<MaybeValue<TValue>> TryGetAsync<TValue>(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default)
+		public async ValueTask<MaybeValue<TValue>> TryGetAsync<TValue>(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default)
 		{
 			ValidateCacheKey(key);
 
@@ -852,7 +852,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		}
 
 		/// <inheritdoc/>
-		public async Task<TValue> GetOrDefaultAsync<TValue>(string key, TValue defaultValue = default, FusionCacheEntryOptions? options = null, CancellationToken token = default)
+		public async ValueTask<TValue> GetOrDefaultAsync<TValue>(string key, TValue defaultValue = default, FusionCacheEntryOptions? options = null, CancellationToken token = default)
 		{
 			ValidateCacheKey(key);
 
@@ -912,7 +912,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		}
 
 		/// <inheritdoc/>
-		public async Task SetAsync<TValue>(string key, TValue value, FusionCacheEntryOptions? options = null, CancellationToken token = default)
+		public async ValueTask SetAsync<TValue>(string key, TValue value, FusionCacheEntryOptions? options = null, CancellationToken token = default)
 		{
 			ValidateCacheKey(key);
 
@@ -976,7 +976,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		}
 
 		/// <inheritdoc/>
-		public async Task RemoveAsync(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default)
+		public async ValueTask RemoveAsync(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default)
 		{
 			ValidateCacheKey(key);
 

--- a/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods.cs
@@ -22,7 +22,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.DefaultEntryOptions"/>.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 		/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
-		public static Task<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue, TimeSpan duration, CancellationToken token = default)
+		public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue, TimeSpan duration, CancellationToken token = default)
 		{
 			return cache.GetOrSetAsync<TValue>(key, factory, failSafeDefaultValue, cache.DefaultEntryOptions.Duplicate(duration), token);
 		}
@@ -54,7 +54,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.DefaultEntryOptions"/>.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 		/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
-		public static Task<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
+		public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 		{
 			return cache.GetOrSetAsync<TValue>(key, factory, failSafeDefaultValue, cache.CreateEntryOptions(setupAction), token);
 		}
@@ -89,7 +89,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="FusionCacheOptions.DefaultEntryOptions"/> will be used.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 		/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
-		public static Task<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, FusionCacheEntryOptions? options, CancellationToken token = default)
+		public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, FusionCacheEntryOptions? options, CancellationToken token = default)
 		{
 			return cache.GetOrSetAsync<TValue>(key, factory, default, options, token);
 		}
@@ -119,7 +119,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.DefaultEntryOptions"/>.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 		/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
-		public static Task<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, TimeSpan duration, CancellationToken token = default)
+		public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, TimeSpan duration, CancellationToken token = default)
 		{
 			return cache.GetOrSetAsync<TValue>(key, factory, default, cache.DefaultEntryOptions.Duplicate(duration), token);
 		}
@@ -149,7 +149,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.DefaultEntryOptions"/>.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 		/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
-		public static Task<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
+		public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, Func<CancellationToken, Task<TValue>> factory, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 		{
 			return cache.GetOrSetAsync<TValue>(key, factory, default, cache.CreateEntryOptions(setupAction), token);
 		}
@@ -182,7 +182,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="defaultValue">In case the value is not in the cache this value will be saved and returned instead.</param>
 		/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.DefaultEntryOptions"/>.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
-		public static Task<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, TValue defaultValue, TimeSpan duration, CancellationToken token = default)
+		public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, TValue defaultValue, TimeSpan duration, CancellationToken token = default)
 		{
 			return cache.GetOrSetAsync<TValue>(key, defaultValue, cache.DefaultEntryOptions.Duplicate(duration), token);
 		}
@@ -210,7 +210,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="defaultValue">In case the value is not in the cache this value will be saved and returned instead.</param>
 		/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.DefaultEntryOptions"/>.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
-		public static Task<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, TValue defaultValue, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
+		public static ValueTask<TValue> GetOrSetAsync<TValue>(this IFusionCache cache, string key, TValue defaultValue, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 		{
 			return cache.GetOrSetAsync<TValue>(key, defaultValue, cache.CreateEntryOptions(setupAction), token);
 		}
@@ -243,7 +243,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.DefaultEntryOptions"/>.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 		/// <returns>The value in the cache or the <paramref name="defaultValue"/> .</returns>
-		public static Task<TValue> GetOrDefaultAsync<TValue>(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, TValue defaultValue = default, CancellationToken token = default)
+		public static ValueTask<TValue> GetOrDefaultAsync<TValue>(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, TValue defaultValue = default, CancellationToken token = default)
 		{
 #pragma warning disable CS8604 // Possible null reference argument.
 			return cache.GetOrDefaultAsync<TValue>(key, defaultValue, cache.CreateEntryOptions(setupAction), token);
@@ -277,7 +277,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.DefaultEntryOptions"/>.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 		/// <returns>The value in the cache or the <paramref name="defaultValue"/> .</returns>
-		public static Task<TValue> GetOrDefaultAsync<TValue>(this IFusionCache cache, string key, TValue defaultValue, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
+		public static ValueTask<TValue> GetOrDefaultAsync<TValue>(this IFusionCache cache, string key, TValue defaultValue, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 		{
 #pragma warning disable CS8604 // Possible null reference argument.
 			return cache.GetOrDefaultAsync<TValue>(key, defaultValue, cache.CreateEntryOptions(setupAction), token);
@@ -313,7 +313,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="key">The cache key which identifies the entry in the cache.</param>
 		/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.DefaultEntryOptions"/>.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
-		public static Task<MaybeValue<TValue>> TryGetAsync<TValue>(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
+		public static ValueTask<MaybeValue<TValue>> TryGetAsync<TValue>(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 		{
 			return cache.TryGetAsync<TValue>(key, cache.CreateEntryOptions(setupAction), token);
 		}
@@ -345,7 +345,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="duration">The value for the newly created <see cref="FusionCacheEntryOptions.Duration"/> property, automatically created by duplicating <see cref="FusionCacheOptions.DefaultEntryOptions"/>.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 		/// <returns>A <see cref="Task"/> to await the completion of the operation.</returns>
-		public static Task SetAsync<TValue>(this IFusionCache cache, string key, TValue value, TimeSpan duration, CancellationToken token = default)
+		public static ValueTask SetAsync<TValue>(this IFusionCache cache, string key, TValue value, TimeSpan duration, CancellationToken token = default)
 		{
 			return cache.SetAsync<TValue>(key, value, cache.DefaultEntryOptions.Duplicate(duration), token);
 		}
@@ -374,7 +374,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.DefaultEntryOptions"/>.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 		/// <returns>A <see cref="Task"/> to await the completion of the operation.</returns>
-		public static Task SetAsync<TValue>(this IFusionCache cache, string key, TValue value, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
+		public static ValueTask SetAsync<TValue>(this IFusionCache cache, string key, TValue value, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 		{
 			return cache.SetAsync<TValue>(key, value, cache.CreateEntryOptions(setupAction), token);
 		}
@@ -405,7 +405,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="setupAction">The setup action used to further configure the newly created <see cref="FusionCacheEntryOptions"/> object, automatically created by duplicating <see cref="FusionCacheOptions.DefaultEntryOptions"/>.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 		/// <returns>A <see cref="Task"/> to await the completion of the operation.</returns>
-		public static Task RemoveAsync(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
+		public static ValueTask RemoveAsync(this IFusionCache cache, string key, Action<FusionCacheEntryOptions> setupAction, CancellationToken token = default)
 		{
 			return cache.RemoveAsync(key, cache.CreateEntryOptions(setupAction), token);
 		}

--- a/src/ZiggyCreatures.FusionCache/IFusionCache.cs
+++ b/src/ZiggyCreatures.FusionCache/IFusionCache.cs
@@ -51,7 +51,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 		/// <returns>The value in the cache, either already there or generated using the provided <paramref name="factory"/> .</returns>
-		Task<TValue> GetOrSetAsync<TValue>(string key, Func<CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue = default, FusionCacheEntryOptions? options = null, CancellationToken token = default);
+		ValueTask<TValue> GetOrSetAsync<TValue>(string key, Func<CancellationToken, Task<TValue>> factory, MaybeValue<TValue> failSafeDefaultValue = default, FusionCacheEntryOptions? options = null, CancellationToken token = default);
 
 		/// <summary>
 		/// Get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/>: if not there, the <paramref name="factory"/> will be called and the returned value saved according to the <paramref name="options"/> provided.
@@ -73,7 +73,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="defaultValue">In case the value is not in the cache this value will be saved and returned instead.</param>
 		/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
-		Task<TValue> GetOrSetAsync<TValue>(string key, TValue defaultValue, FusionCacheEntryOptions? options = null, CancellationToken token = default);
+		ValueTask<TValue> GetOrSetAsync<TValue>(string key, TValue defaultValue, FusionCacheEntryOptions? options = null, CancellationToken token = default);
 
 		/// <summary>
 		/// Get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/>: if not there, the <paramref name="defaultValue"/> will be saved according to the <paramref name="options"/> provided.
@@ -94,7 +94,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 		/// <returns>The value in the cache or the <paramref name="defaultValue"/> .</returns>
-		Task<TValue> GetOrDefaultAsync<TValue>(string key, TValue defaultValue = default, FusionCacheEntryOptions? options = null, CancellationToken token = default);
+		ValueTask<TValue> GetOrDefaultAsync<TValue>(string key, TValue defaultValue = default, FusionCacheEntryOptions? options = null, CancellationToken token = default);
 
 		/// <summary>
 		/// Get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/>: if not there, the <paramref name="defaultValue"/> will be returned.
@@ -114,7 +114,7 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="key">The cache key which identifies the entry in the cache.</param>
 		/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
-		Task<MaybeValue<TValue>> TryGetAsync<TValue>(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default);
+		ValueTask<MaybeValue<TValue>> TryGetAsync<TValue>(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default);
 
 		/// <summary>
 		/// Try to get the value of type <typeparamref name="TValue"/> in the cache for the specified <paramref name="key"/> and returns a <see cref="MaybeValue{TValue}"/> instance.
@@ -133,8 +133,8 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="value">The value to put in the cache.</param>
 		/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
-		/// <returns>A <see cref="Task"/> to await the completion of the operation.</returns>
-		Task SetAsync<TValue>(string key, TValue value, FusionCacheEntryOptions? options = null, CancellationToken token = default);
+		/// <returns>A <see cref="ValueTask"/> to await the completion of the operation.</returns>
+		ValueTask SetAsync<TValue>(string key, TValue value, FusionCacheEntryOptions? options = null, CancellationToken token = default);
 
 		/// <summary>
 		/// Put the <paramref name="value"/> in the cache for the specified <paramref name="key"/> with the provided <paramref name="options"/>. If a value is already there it will be overwritten.
@@ -152,8 +152,8 @@ namespace ZiggyCreatures.Caching.Fusion
 		/// <param name="key">The cache key which identifies the entry in the cache.</param>
 		/// <param name="options">The options to adhere during this operation. If null is passed, <see cref="DefaultEntryOptions"/> will be used.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
-		/// <returns>A <see cref="Task"/> to await the completion of the operation.</returns>
-		Task RemoveAsync(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default);
+		/// <returns>A <see cref="ValueTask"/> to await the completion of the operation.</returns>
+		ValueTask RemoveAsync(string key, FusionCacheEntryOptions? options = null, CancellationToken token = default);
 
 		/// <summary>
 		/// Removes the value in the cache for the specified <paramref name="key"/>.

--- a/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor.cs
@@ -117,7 +117,7 @@ namespace ZiggyCreatures.Caching.Fusion.Internals.Distributed
 		}
 
 		//[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private async Task ExecuteOperationAsync(string operationId, string key, Func<CancellationToken, Task> action, string actionDescription, FusionCacheEntryOptions options, DistributedCacheEntryOptions? distributedOptions, CancellationToken token)
+		private async ValueTask ExecuteOperationAsync(string operationId, string key, Func<CancellationToken, Task> action, string actionDescription, FusionCacheEntryOptions options, DistributedCacheEntryOptions? distributedOptions, CancellationToken token)
 		{
 			if (IsCurrentlyUsable() == false)
 				return;
@@ -167,7 +167,7 @@ namespace ZiggyCreatures.Caching.Fusion.Internals.Distributed
 			);
 		}
 
-		public async Task SetEntryAsync<TValue>(string operationId, string key, IFusionCacheEntry entry, FusionCacheEntryOptions options, CancellationToken token)
+		public async ValueTask SetEntryAsync<TValue>(string operationId, string key, IFusionCacheEntry entry, FusionCacheEntryOptions options, CancellationToken token)
 		{
 			if (IsCurrentlyUsable() == false)
 				return;
@@ -281,7 +281,7 @@ namespace ZiggyCreatures.Caching.Fusion.Internals.Distributed
 			);
 		}
 
-		public async Task<(FusionCacheDistributedEntry<TValue>? entry, bool isValid)> TryGetEntryAsync<TValue>(string operationId, string key, FusionCacheEntryOptions options, bool hasFallbackValue, CancellationToken token)
+		public async ValueTask<(FusionCacheDistributedEntry<TValue>? entry, bool isValid)> TryGetEntryAsync<TValue>(string operationId, string key, FusionCacheEntryOptions options, bool hasFallbackValue, CancellationToken token)
 		{
 			if (IsCurrentlyUsable() == false)
 				return (null, false);
@@ -431,7 +431,7 @@ namespace ZiggyCreatures.Caching.Fusion.Internals.Distributed
 			return (null, false);
 		}
 
-		public async Task RemoveEntryAsync(string operationId, string key, FusionCacheEntryOptions options, CancellationToken token)
+		public async ValueTask RemoveEntryAsync(string operationId, string key, FusionCacheEntryOptions options, CancellationToken token)
 		{
 			await ExecuteOperationAsync(operationId, key, ct => _cache.RemoveAsync(WireFormatVersionPrefix + key, ct), "removing entry from distributed", options, null, token);
 

--- a/src/ZiggyCreatures.FusionCache/Plugins/IFusionCachePlugin.cs
+++ b/src/ZiggyCreatures.FusionCache/Plugins/IFusionCachePlugin.cs
@@ -1,5 +1,8 @@
 ﻿namespace ZiggyCreatures.Caching.Fusion.Plugins
 {
+	/// <summary>
+	/// The core plugin interface to implement to create a FusionCache plugin.
+	/// </summary>
 	public interface IFusionCachePlugin
 	{
 		/// <summary>

--- a/src/ZiggyCreatures.FusionCache/Reactors/FusionCacheReactorProbabilistic.cs
+++ b/src/ZiggyCreatures.FusionCache/Reactors/FusionCacheReactorProbabilistic.cs
@@ -38,7 +38,7 @@ namespace ZiggyCreatures.Caching.Fusion.Reactors
 		}
 
 		// ACQUIRE LOCK ASYNC
-		public async Task<object?> AcquireLockAsync(string key, string operationId, TimeSpan timeout, ILogger? logger, CancellationToken token)
+		public async ValueTask<object?> AcquireLockAsync(string key, string operationId, TimeSpan timeout, ILogger? logger, CancellationToken token)
 		{
 			token.ThrowIfCancellationRequested();
 

--- a/src/ZiggyCreatures.FusionCache/Reactors/FusionCacheReactorStandard.cs
+++ b/src/ZiggyCreatures.FusionCache/Reactors/FusionCacheReactorStandard.cs
@@ -75,7 +75,7 @@ namespace ZiggyCreatures.Caching.Fusion.Reactors
 		}
 
 		// ACQUIRE LOCK ASYNC
-		public async Task<object?> AcquireLockAsync(string key, string operationId, TimeSpan timeout, ILogger? logger, CancellationToken token)
+		public async ValueTask<object?> AcquireLockAsync(string key, string operationId, TimeSpan timeout, ILogger? logger, CancellationToken token)
 		{
 			token.ThrowIfCancellationRequested();
 

--- a/src/ZiggyCreatures.FusionCache/Reactors/IFusionCacheReactor.cs
+++ b/src/ZiggyCreatures.FusionCache/Reactors/IFusionCacheReactor.cs
@@ -20,7 +20,7 @@ namespace ZiggyCreatures.Caching.Fusion.Reactors
 		/// <param name="logger">The <see cref="ILogger"/> to use, if any.</param>
 		/// <param name="token">An optional <see cref="CancellationToken"/> to cancel the operation.</param>
 		/// <returns>The acquired genericlock object, later released when the crytical section is over.</returns>
-		Task<object?> AcquireLockAsync(string key, string operationId, TimeSpan timeout, ILogger? logger, CancellationToken token);
+		ValueTask<object?> AcquireLockAsync(string key, string operationId, TimeSpan timeout, ILogger? logger, CancellationToken token);
 
 		/// <summary>
 		/// Acquire a generic lock, used to synchronize multiple factory operating on the same cache key, and return it.

--- a/src/ZiggyCreatures.FusionCache/Serialization/IFusionCacheSerializer.cs
+++ b/src/ZiggyCreatures.FusionCache/Serialization/IFusionCacheSerializer.cs
@@ -29,7 +29,7 @@ namespace ZiggyCreatures.Caching.Fusion.Serialization
 		/// <typeparam name="T">The type of the <paramref name="obj"/> parameter.</typeparam>
 		/// <param name="obj"></param>
 		/// <returns>The byte[] which represents the serialized <paramref name="obj"/>.</returns>
-		Task<byte[]> SerializeAsync<T>(T obj);
+		ValueTask<byte[]> SerializeAsync<T>(T obj);
 
 		/// <summary>
 		/// Deserialized the specified byte[] <paramref name="data"/> into an object of type <typeparamref name="T"/>.
@@ -37,6 +37,6 @@ namespace ZiggyCreatures.Caching.Fusion.Serialization
 		/// <typeparam name="T">The type of the object to be returned.</typeparam>
 		/// <param name="data"></param>
 		/// <returns>The deserialized object.</returns>
-		Task<T> DeserializeAsync<T>(byte[] data);
+		ValueTask<T> DeserializeAsync<T>(byte[] data);
 	}
 }

--- a/src/ZiggyCreatures.FusionCache/ZiggyCreatures.FusionCache.csproj
+++ b/src/ZiggyCreatures.FusionCache/ZiggyCreatures.FusionCache.csproj
@@ -30,7 +30,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MailKit" Version="2.13.0" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.10" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 	</ItemGroup>

--- a/src/ZiggyCreatures.FusionCache/ZiggyCreatures.FusionCache.csproj
+++ b/src/ZiggyCreatures.FusionCache/ZiggyCreatures.FusionCache.csproj
@@ -32,6 +32,7 @@
 	<ItemGroup>
 		<PackageReference Include="MailKit" Version="2.13.0" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.10" />
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 	</ItemGroup>
 
 </Project>

--- a/src/ZiggyCreatures.FusionCache/ZiggyCreatures.FusionCache.xml
+++ b/src/ZiggyCreatures.FusionCache/ZiggyCreatures.FusionCache.xml
@@ -1264,7 +1264,7 @@
             <param name="value">The value to put in the cache.</param>
             <param name="options">The options to adhere during this operation. If null is passed, <see cref="P:ZiggyCreatures.Caching.Fusion.IFusionCache.DefaultEntryOptions"/> will be used.</param>
             <param name="token">An optional <see cref="T:System.Threading.CancellationToken"/> to cancel the operation.</param>
-            <returns>A <see cref="T:System.Threading.Tasks.Task"/> to await the completion of the operation.</returns>
+            <returns>A <see cref="T:System.Threading.Tasks.ValueTask"/> to await the completion of the operation.</returns>
         </member>
         <member name="M:ZiggyCreatures.Caching.Fusion.IFusionCache.Set``1(System.String,``0,ZiggyCreatures.Caching.Fusion.FusionCacheEntryOptions,System.Threading.CancellationToken)">
             <summary>
@@ -1283,7 +1283,7 @@
             <param name="key">The cache key which identifies the entry in the cache.</param>
             <param name="options">The options to adhere during this operation. If null is passed, <see cref="P:ZiggyCreatures.Caching.Fusion.IFusionCache.DefaultEntryOptions"/> will be used.</param>
             <param name="token">An optional <see cref="T:System.Threading.CancellationToken"/> to cancel the operation.</param>
-            <returns>A <see cref="T:System.Threading.Tasks.Task"/> to await the completion of the operation.</returns>
+            <returns>A <see cref="T:System.Threading.Tasks.ValueTask"/> to await the completion of the operation.</returns>
         </member>
         <member name="M:ZiggyCreatures.Caching.Fusion.IFusionCache.Remove(System.String,ZiggyCreatures.Caching.Fusion.FusionCacheEntryOptions,System.Threading.CancellationToken)">
             <summary>
@@ -1653,6 +1653,11 @@
             </summary>
             <param name="value">The value of type <typeparamref name="TValue"/> to use.</param>
             <returns>The newly created <see cref="T:ZiggyCreatures.Caching.Fusion.MaybeValue`1"/> instance.</returns>
+        </member>
+        <member name="T:ZiggyCreatures.Caching.Fusion.Plugins.IFusionCachePlugin">
+            <summary>
+            The core plugin interface to implement to create a FusionCache plugin.
+            </summary>
         </member>
         <member name="M:ZiggyCreatures.Caching.Fusion.Plugins.IFusionCachePlugin.Start(ZiggyCreatures.Caching.Fusion.IFusionCache)">
             <summary>

--- a/tests/ZiggyCreatures.FusionCache.Tests/ConcurrentFactoryCallsTests.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/ConcurrentFactoryCallsTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,7 +35,7 @@ namespace ZiggyCreatures.Caching.Fusion.Tests
 						},
 						new FusionCacheEntryOptions(TimeSpan.FromSeconds(10))
 					);
-					tasks.Add(task);
+					tasks.Add(task.AsTask());
 				});
 
 				await Task.WhenAll(tasks);
@@ -97,7 +97,7 @@ namespace ZiggyCreatures.Caching.Fusion.Tests
 						   },
 						   new FusionCacheEntryOptions(TimeSpan.FromSeconds(10))
 					   );
-						tasks.Add(task);
+						tasks.Add(task.AsTask());
 					}
 					else
 					{


### PR DESCRIPTION
This PR switches every main usage of Task<T> to ValueTask<T> in all public apis, to help save some memory allocations.