### PR TITLE
Take into account failSafeDefaultValue for factory timeout

### DIFF
--- a/src/ZiggyCreatures.FusionCache/FusionCache_Async.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCache_Async.cs
@@ -172,7 +172,7 @@ namespace ZiggyCreatures.Caching.Fusion
 
 						Task<TValue>? factoryTask = null;
 
-						var timeout = options.GetAppropriateFactoryTimeout(memoryEntry is object || distributedEntry is object);
+						var timeout = options.GetAppropriateFactoryTimeout(memoryEntry is object || distributedEntry is object || failSafeDefaultValue.HasValue);
 
 						if (_logger?.IsEnabled(LogLevel.Debug) ?? false)
 							_logger.LogDebug("FUSION (O={CacheOperationId} K={CacheKey}): calling the factory (timeout={Timeout})", operationId, key, timeout.ToLogString_Timeout());

--- a/src/ZiggyCreatures.FusionCache/FusionCache_Sync.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCache_Sync.cs
@@ -172,7 +172,7 @@ namespace ZiggyCreatures.Caching.Fusion
 
 						Task<TValue>? factoryTask = null;
 
-						var timeout = options.GetAppropriateFactoryTimeout(memoryEntry is object || distributedEntry is object);
+						var timeout = options.GetAppropriateFactoryTimeout(memoryEntry is object || distributedEntry is object || failSafeDefaultValue.HasValue);
 
 						if (_logger?.IsEnabled(LogLevel.Debug) ?? false)
 							_logger.LogDebug("FUSION (O={CacheOperationId} K={CacheKey}): calling the factory (timeout={Timeout})", operationId, key, timeout.ToLogString_Timeout());


### PR DESCRIPTION
Hi Jody!

We started using FusionCache at my company and encountered a strange case when dealing with factory tiemouts and failsafe values.

What happens is that when doing a `GetOrSetAsync` call specifying a factory and its soft timeout and a failsafe value, I expected the factory to terminate after the soft timeout expires and for the call to return the default failsafe value, but it keeps running until finished. This prevents being able to run a fail-fast scenario in first time cache calls.

I've prepared a PoC based on the scenarios on `ZiggyCreatures.FusionCache.Playground`, this is the simplest case I could came up with, no distributed cache, only in memory and no other options:
```
using System;
using System.Diagnostics;
using System.Text;
using System.Threading.Tasks;
using Microsoft.Extensions.DependencyInjection;
using Microsoft.Extensions.Logging;
using Serilog;
using Serilog.Events;

namespace ZiggyCreatures.Caching.Fusion.Playground.Scenarios
{
	public static class SoftTimeoutTestScenario
	{
		private static readonly bool UseLogger = true;

		private static void SetupSerilogLogger(IServiceCollection services, LogEventLevel minLevel = LogEventLevel.Verbose)
		{
			Log.Logger = new LoggerConfiguration()
				.MinimumLevel.Is(minLevel)
				.Enrich.FromLogContext()
				.WriteTo.Console()
				.CreateLogger()
			;

			services.AddLogging(configure => configure.AddSerilog());
		}

		private static void SetupStandardLogger(IServiceCollection services, LogLevel minLevel = LogLevel.Trace)
		{
			services.AddLogging(configure => configure.SetMinimumLevel(minLevel).AddConsole(options => options.IncludeScopes = true));
		}

		public static async Task RunAsync()
		{
			Console.OutputEncoding = Encoding.UTF8;

			// DI
			var services = new ServiceCollection();

			SetupSerilogLogger(services);

			var serviceProvider = services.BuildServiceProvider();

			var logger = UseLogger ? serviceProvider.GetService<ILogger<FusionCache>>() : null;

			// CACHE OPTIONS
			var options = new FusionCacheOptions();

			using (var fusionCache = new FusionCache(options, logger: logger))
			{
				var sw = Stopwatch.StartNew();

				var myValue = await fusionCache.GetOrSetAsync(
					"thekey",
					async (ctx, ct) =>
					{
						await Task.Delay(TimeSpan.FromMilliseconds(5000));

						return "thevalue";
					},
					failSafeDefaultValue: null,
					options => options
						.SetFailSafe(true)
						.SetFactoryTimeouts(TimeSpan.FromMilliseconds(100))
						.SetDuration(TimeSpan.FromMinutes(1))
					);

				sw.Stop();
				Console.WriteLine($"Fusiocache returned an object with value {myValue} in {sw.ElapsedMilliseconds} ms");

				Console.WriteLine("\n\nTHE END");
			}
		}
	}
}
```

When running this code you'll get a message saying
> Fusiocache returned an object with value thevalue in 5117 ms

or some similar time value, even though `.SetFactoryTimeouts(TimeSpan.FromMilliseconds(100))` was specified.

Diving into the library's code if narrowed down the tiemout selection to this call: `var timeout = options.GetAppropriateFactoryTimeout(memoryEntry is object || distributedEntry is object);`. I understand that the factory soft timeout is only set up when there's a "normal" failsafe value, one that was returned correctly in a previous call. But it doesn't take into account a possible `failSafeDefaultValue`.

In this pull request proposal I've added the check to take into account the `failSafeDefaultValue`, but would like to get your input on this in case I'm missing something.